### PR TITLE
Updated Compatibility List - G933 and K860

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,8 @@ The hidapi backend is rewritten in C++, and it differs from HID.NET in the follo
 - MX Vertical
 - G703 Lightspeed Wireless
 - G502 Lightspeed Wireless
+- G933 Gaming Wireless Headset
+- ERGO K860 for Business
 
 ## How to Build project
 Run `prepare_project.bat` to generate the C++ Visual studio project that can be linked with the C# project.


### PR DESCRIPTION
Added tested headset "Logitech G933 Gaming Wireless Headset" and keyboard "ERGO K860 for Business". Battery indicator is working for both devices.