### PR TITLE
Fixed GHub startup exception

### DIFF
--- a/LGSTrayGHUB/GHUBDeviceManager.cs
+++ b/LGSTrayGHUB/GHUBDeviceManager.cs
@@ -139,21 +139,33 @@ namespace LGSTrayGHUB
         {
             _LogiDevices.Clear();
 
-            foreach (var deviceToken in payload["deviceInfos"])
+            try 
             {
-                if (!Enum.TryParse(deviceToken["deviceType"].ToString(), true, out DeviceType deviceType))
+                foreach (var deviceToken in payload["deviceInfos"])
                 {
-                    deviceType = DeviceType.Mouse;
+                    if(deviceToken["state"].ToString() == "NOT_CONNECTED")
+                    {
+                        continue;
+                    }
+
+                    if (!Enum.TryParse(deviceToken["deviceType"].ToString(), true, out DeviceType deviceType))
+                    {
+                        deviceType = DeviceType.Mouse;
+                    }
+
+                    LogiDeviceGHUB device = new LogiDeviceGHUB()
+                    {
+                        DeviceID = deviceToken["id"].ToString(),
+                        DeviceName = deviceToken["extendedDisplayName"].ToString(),
+                        DeviceType = deviceType
+                    };
+
+                    _LogiDevices.Add(device);
                 }
-
-                LogiDeviceGHUB device = new LogiDeviceGHUB()
-                {
-                    DeviceID = deviceToken["id"].ToString(),
-                    DeviceName = deviceToken["extendedDisplayName"].ToString(),
-                    DeviceType = deviceType
-                };
-
-                _LogiDevices.Add(device);
+            } catch (Exception e) {
+                if(e is NullReferenceException || e is JsonReaderException) {
+                    Debug.WriteLine("Failed to parse device list, LGHUB_agent is probably starting up");
+                }
             }
 
             UpdateDevicesAsync().Wait();

--- a/LGSTrayGHUB/GHUBDeviceManager.cs
+++ b/LGSTrayGHUB/GHUBDeviceManager.cs
@@ -143,11 +143,6 @@ namespace LGSTrayGHUB
             {
                 foreach (var deviceToken in payload["deviceInfos"])
                 {
-                    if(deviceToken["state"].ToString() == "NOT_CONNECTED")
-                    {
-                        continue;
-                    }
-
                     if (!Enum.TryParse(deviceToken["deviceType"].ToString(), true, out DeviceType deviceType))
                     {
                         deviceType = DeviceType.Mouse;

--- a/LGSTrayGUI/MainWindowViewModel.cs
+++ b/LGSTrayGUI/MainWindowViewModel.cs
@@ -153,6 +153,11 @@ namespace LGSTrayGUI
         {
             ObservableCollection<LogiDevice> managedDevices = new();
             managedDevices.CollectionChanged += (o, e) => {
+                if(e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset) {
+                    if(SelectedDevice != null) {
+                        SelectedDevice.InvokePropertyChanged(null, new PropertyChangedEventArgs("LastUpdate"));
+                    }
+                }
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LogiDevicesFlat)));
             };
 
@@ -169,11 +174,6 @@ namespace LGSTrayGUI
 
         private void UpdateSelectedDeviceOnLaunch(object sender, PropertyChangedEventArgs e)
         {
-            if (SelectedDevice != null || e.PropertyName != nameof(LogiDevicesFlat))
-            {
-                return;
-            }
-
             LogiDevice found = LogiDevicesFlat.FirstOrDefault(x => x.DeviceID == Properties.Settings.Default.LastSelectedDeviceId);
             if (found != null)
             {

--- a/LGSTrayGUI/MainWindowViewModel.cs
+++ b/LGSTrayGUI/MainWindowViewModel.cs
@@ -153,11 +153,6 @@ namespace LGSTrayGUI
         {
             ObservableCollection<LogiDevice> managedDevices = new();
             managedDevices.CollectionChanged += (o, e) => {
-                if(e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset) {
-                    if(SelectedDevice != null) {
-                        SelectedDevice.InvokePropertyChanged(null, new PropertyChangedEventArgs("LastUpdate"));
-                    }
-                }
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LogiDevicesFlat)));
             };
 


### PR DESCRIPTION
During startup GHUB sends a short JSON message which includes only one property `@types` which causes `_loadDevices` function to throw an exception. This commit should fix this

I also included a fix, that tracks if the device goes offline - Icon goes to unknown until the device is online again. 