### PR TITLE
FIX for device selection (did not work on first attempt)

### DIFF
--- a/LGSTrayGUI/MainWindowViewModel.cs
+++ b/LGSTrayGUI/MainWindowViewModel.cs
@@ -82,13 +82,13 @@ namespace LGSTrayGUI
                     _SelectedDevice.PropertyChanged -= UpdateBatteryIcon;
                 }
 
+                Properties.Settings.Default.LastSelectedDeviceId = value.DeviceID;
+                Properties.Settings.Default.Save();
+
                 _SelectedDevice = value;
                 _SelectedDevice.PropertyChanged += UpdateBatteryIcon;
                 _SelectedDevice.InvokePropertyChanged(value, new PropertyChangedEventArgs("LastUpdate"));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedDevice)));
-
-                Properties.Settings.Default.LastSelectedDeviceId = value.DeviceID;
-                Properties.Settings.Default.Save();
             }
         }
 


### PR DESCRIPTION
Set Settings.LastSelectedDeviceId before applying the value to _SelectedDevice, because applying the value triggers UpdateSelectedDeviceOnLaunch which relys on the setting.

Due to this it was required to select a device twice to make it actually the selected device.