### PR TITLE
Fix: invoke DestroyIcon after swap icon object to avoid GDI handles leak

### DIFF
--- a/LGSTrayGUI/MainWindowViewModel.cs
+++ b/LGSTrayGUI/MainWindowViewModel.cs
@@ -98,8 +98,9 @@ namespace LGSTrayGUI
             {
                 return;
             }
-
+            var prevIcon = view.TaskbarIcon.Icon;
             view.TaskbarIcon.Icon = TrayIconTools.GenerateIcon(sender as LogiDevice);
+            TrayIconTools.DisposeIcon(prevIcon);
         }
 
         public IEnumerable<LogiDevice> LogiDevicesFlat { get => LogiDevices.SelectMany(x => x); }

--- a/LGSTrayGUI/TrayIconTools.cs
+++ b/LGSTrayGUI/TrayIconTools.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -90,6 +91,15 @@ namespace LGSTrayGUI
             }
 
             return Icon.FromHandle(output.GetHicon());
+        }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = CharSet.Auto)]
+        extern static bool DestroyIcon(IntPtr handle);
+
+        public static void DisposeIcon(Icon icon)
+        {
+            icon.Dispose();
+            DestroyIcon(icon.Handle);
         }
     }
 }


### PR DESCRIPTION
After a long time execution of LGSTrayGUI, the main process may crash with the following crashlog:

```plaintext
System.Runtime.InteropServices.ExternalException (0x80004005): A generic error occurred in GDI+.
   at System.Drawing.Bitmap.GetHicon()
   at LGSTrayGUI.TrayIconTools.GenerateIcon(LogiDevice logiDevice) in E:\repos\LGSTrayBattery\LGSTrayGUI\TrayIconTools.cs:line 80
   at LGSTrayGUI.MainWindowViewModel.UpdateBatteryIcon(Object sender, PropertyChangedEventArgs e) in E:\repos\LGSTrayBattery\LGSTrayGUI\MainWindowViewModel.cs:line 99
   at LGSTrayCore.LogiDevice.set_LastUpdate(DateTime value) in E:\repos\LGSTrayBattery\LGSTrayCore\LogiDevice.cs:line 27
   at LGSTrayGHUB.NativeDeviceManager.battery_update_cb(String dev_id, Int32 bat_percent, Boolean charging, Double mileage, Int32 bat_mv) in E:\repos\LGSTrayBattery\LGSTrayNative\NativeDeviceManager.cs:line 73
```

This behavior can be observed by the GDI objects count in Task Manager, which is increasing steadily.
According to [Icon.FromHandle: should I Dispose it, or call DestroyIcon?](https://stackoverflow.com/questions/30979653/icon-fromhandle-should-i-dispose-it-or-call-destroyicon), we should invoke `DestroyIcon` win32api to clean the GDI handle and avoid leaking. After applying this change, the GDI objects count will remain below 100.

This pull request has the potential to address issue #64 as well.