### PR TITLE
Update BatteryIconDrawing.cs

### DIFF
--- a/LGSTrayUI/BatteryIconDrawing.cs
+++ b/LGSTrayUI/BatteryIconDrawing.cs
@@ -7,6 +7,8 @@ using System.Drawing.Imaging;
 using Hardcodet.Wpf.TaskbarNotification;
 using System.Runtime.InteropServices;
 using LGSTrayPrimitives;
+using System.Drawing.Text;
+using System.Windows;
 
 namespace LGSTrayUI
 {
@@ -23,7 +25,7 @@ namespace LGSTrayUI
         private static Bitmap Missing => CheckTheme.LightTheme ? Resources.Missing : Resources.Missing_dark;
         private static Bitmap Charging => CheckTheme.LightTheme ? Resources.Charging : Resources.Charging_dark;
 
-        private const int ImageSize = 256;
+        private static int ImageSize = (int) SystemParameters.SmallIconHeight;
 
         private static Bitmap GetDeviceIcon(LogiDevice device) => device.DeviceType switch
         {
@@ -103,6 +105,12 @@ namespace LGSTrayUI
             using Graphics g = Graphics.FromImage(b);
 
             string displayString = (device.BatteryPercentage < 0) ? "?" : $"{device.BatteryPercentage:f0}";
+            g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+            g.CompositingMode = CompositingMode.SourceOver;
+            g.CompositingQuality = CompositingQuality.HighQuality;
+            g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            g.PixelOffsetMode = PixelOffsetMode.HighQuality;
             g.DrawString(
                 displayString,
                 new Font("Segoe UI", (int) (0.8 * ImageSize), GraphicsUnit.Pixel),
@@ -114,11 +122,6 @@ namespace LGSTrayUI
                     Alignment = StringAlignment.Center,
                 }
             );
-            g.CompositingMode = CompositingMode.SourceOver;
-            g.CompositingQuality = CompositingQuality.HighQuality;
-            g.InterpolationMode = InterpolationMode.NearestNeighbor;
-            g.SmoothingMode = SmoothingMode.HighQuality;
-            g.PixelOffsetMode = PixelOffsetMode.HighQuality;
 
             IntPtr iconHandle = b.GetHicon();
             Icon tempManagedRes = Icon.FromHandle(iconHandle);

--- a/readme.md
+++ b/readme.md
@@ -4,10 +4,10 @@ Forked from andyvorld to fix an issue with the numeric display.  The problem is 
 
 ## How to install
 
-[![GitHub Release](https://img.shields.io/github/v/release/andyvorld/LGSTrayBattery?sort=semver)](https://github.com/andyvorld/LGSTrayBattery/releases/latest)
+[![GitHub Release](https://img.shields.io/github/v/release/tr4npt/LGSTrayBattery?sort=semver)](https://github.com/tr4npt/LGSTrayBattery/releases/latest)
 
 
-Please, visit [the latest release page](https://github.com/andyvorld/LGSTrayBattery/releases/latest) and download the release zip files from assets. Builds with the `-standalone` suffix are pre-bundled with .Net 8 and does not require any further dependencies, the non-standalone version requires .Net 8 to be pre-installed (https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
+Please, visit [the latest release page](https://github.com/tr4npt/LGSTrayBattery/releases/latest) and download the release zip files from assets. Builds with the `-standalone` suffix are pre-bundled with .Net 8 and does not require any further dependencies, the non-standalone version requires .Net 8 to be pre-installed (https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
 
 ## Changes from V2
 *When migrating from earlier versions, device ids may have changed.*

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # LGS Tray Battery
 
-A rewrite/combination of my two programs [LGSTrayBattery](https://github.com/andyvorld/LGSTrayBattery) and [LGSTrayBattery_GHUB](https://github.com/andyvorld/LGSTrayBattery_GHUB), which should allow for interaction via both the native HID and Logitech GaminG Hub websockets.
+Forked from andyvorld to fix an issue with the numeric display.  The problem is that the icon being created was 256x256 and Windows is scaling it down to fit on the taskbar.  All of the blank space is getting averaged with the text pixels due to the sampling algorithm, resulting in bad text.  
 
 ## How to install
 


### PR DESCRIPTION
fix numeric icon text quality issue

The problem is that the bitmap created is too large (256x256), so when Windows scales it down to fit on the taskbar, all of the blank/black space takes priority over the text due to the sampling algorithm