### PR TITLE
Device detect fix

### DIFF
--- a/LGSTrayCore/Managers/GHubManager.cs
+++ b/LGSTrayCore/Managers/GHubManager.cs
@@ -152,22 +152,26 @@ namespace LGSTrayCore.Managers
         protected void ParseSocketMsg(ResponseMessage msg)
         {
             GHUBMsg ghubmsg = GHUBMsg.DeserializeJson(msg.Text!);
+            DiagnosticLogger.Log($"LGHUB message received - Path: {ghubmsg.Path}");
 
             switch (ghubmsg.Path)
             {
                 case "/devices/list":
                     {
+                        DiagnosticLogger.Log("Processing /devices/list response");
                         LoadDevices(ghubmsg.Payload);
                         break;
                     }
                 case "/battery/state/changed":
                 case { } when BatteryDeviceStateRegex().Match(ghubmsg.Path).Success:
                     {
-                        Console.WriteLine(ghubmsg.Path);
+                        DiagnosticLogger.Log($"Processing battery update: {ghubmsg.Path}");
                         ParseBatteryUpdate(ghubmsg.Payload);
                         break;
                     }
-                default: break;
+                default:
+                    DiagnosticLogger.Log($"Unhandled LGHUB message path: {ghubmsg.Path}");
+                    break;
             }
         }
 

--- a/LGSTrayHID/HidppDevice.cs
+++ b/LGSTrayHID/HidppDevice.cs
@@ -15,6 +15,7 @@ namespace LGSTrayHID
 {
     public class HidppDevice
     {
+        private const int INIT_PING_TIMEOUT = 5000;
         private readonly SemaphoreSlim _initSemaphore = new(1, 1);
         private Func<HidppDevice, Task<BatteryUpdateReturn?>>? _getBatteryAsync;
 
@@ -68,7 +69,7 @@ namespace LGSTrayHID
                     DiagnosticLogger.Log($"Starting ping test for HID device index {_deviceIdx}");
                     for (int i = 0; i < 10; i++)
                     {
-                        var ping = await _parent.Ping20(_deviceIdx, 100);
+                        var ping = await _parent.Ping20(_deviceIdx, INIT_PING_TIMEOUT);
                         if (ping)
                         {
                             successCount++;

--- a/LGSTrayHID/HidppDevices.cs
+++ b/LGSTrayHID/HidppDevices.cs
@@ -20,6 +20,8 @@ namespace LGSTrayHID
 
         private bool _isReading = true;
         private const int READ_TIMEOUT = 100;
+        private const int TASK_DELAY = 2000;
+        private const int PING_ENUMERATE_DELAY = 5000;
 
         private readonly Dictionary<ushort, HidppDevice> _deviceCollection = [];
         public IReadOnlyDictionary<ushort, HidppDevice> DeviceCollection => _deviceCollection;
@@ -307,7 +309,7 @@ namespace LGSTrayHID
             t2.Start();
 
             byte[] ret;
-
+            
             // Read number of devices on reciever
             ret = await WriteRead10(_devShort, [0x10, 0xFF, 0x81, 0x02, 0x00, 0x00, 0x00], 1000);
             byte numDeviceFound = 0;
@@ -322,14 +324,14 @@ namespace LGSTrayHID
                 ret = await WriteRead10(_devShort, [0x10, 0xFF, 0x80, 0x02, 0x02, 0x00, 0x00], 1000);
             }
 
-            await Task.Delay(500);
+            await Task.Delay(TASK_DELAY);
 
             if (_deviceCollection.Count == 0)
             {
                 // Fail to enumerate devices
                 for (byte i = 1; i <= 6; i++)
                 {
-                    var ping = await Ping20(i, 100, false);
+                    var ping = await Ping20(i, PING_ENUMERATE_DELAY, false);
                     if (ping)
                     {
                         var deviceIdx = i;

--- a/LGSTrayHID/HidppManagerContext.cs
+++ b/LGSTrayHID/HidppManagerContext.cs
@@ -3,6 +3,7 @@ using static LGSTrayHID.HidApi.HidApiWinApi;
 using static LGSTrayHID.HidApi.HidApiHotPlug;
 using LGSTrayHID.HidApi;
 using System.Collections.Concurrent;
+using LGSTrayPrimitives;
 using LGSTrayPrimitives.MessageStructs;
 
 namespace LGSTrayHID
@@ -39,6 +40,8 @@ namespace LGSTrayHID
         {
             if (hidApiHotPlugEvent == HidApiHotPlugEvent.HID_API_HOTPLUG_EVENT_DEVICE_ARRIVED)
             {
+                string devPath = (*device).GetPath();
+                DiagnosticLogger.Log($"HID device detected: {devPath}");
                 _deviceQueue.Add(*device);
             }
 
@@ -52,10 +55,12 @@ namespace LGSTrayHID
             {
                 case HidppMessageType.NONE:
                 case HidppMessageType.VERY_LONG:
+                    DiagnosticLogger.Log($"Skipping device with unsupported message type: {messageType}");
                     return 0;
             }
 
             string devPath = (deviceInfo).GetPath();
+            DiagnosticLogger.Log($"Initializing HID device: {devPath}");
 
             HidDevicePtr dev = HidOpenPath(ref deviceInfo);
             _ = HidWinApiGetContainerId(dev, out Guid containerId);

--- a/LGSTrayPrimitives/DiagnosticLogger.cs
+++ b/LGSTrayPrimitives/DiagnosticLogger.cs
@@ -12,6 +12,8 @@ public static class DiagnosticLogger
     private static readonly object _lock = new object();
     private static readonly string _logFilePath = Path.Combine(AppContext.BaseDirectory, "diagnostic.log");
 
+    public static bool Enable { get; set; } = false;
+
     /// <summary>
     /// Log an informational message with timestamp.
     /// </summary>
@@ -47,6 +49,8 @@ public static class DiagnosticLogger
 
     private static void WriteToFile(string message)
     {
+        if (!Enable) return;
+
         try
         {
             lock (_lock)
@@ -58,5 +62,10 @@ public static class DiagnosticLogger
         {
             // Silently fail if we can't write to log file
         }
+    }
+
+    public static void ResetLog()
+    {    
+        File.WriteAllText(_logFilePath, string.Empty);
     }
 }

--- a/LGSTrayPrimitives/DiagnosticLogger.cs
+++ b/LGSTrayPrimitives/DiagnosticLogger.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics;
+
+namespace LGSTrayPrimitives;
+
+/// <summary>
+/// Diagnostic logger for tracing device discovery and UI updates.
+/// Writes to diagnostic.log file in the application directory.
+/// Works in both Debug and Release builds.
+/// </summary>
+public static class DiagnosticLogger
+{
+    private static readonly object _lock = new object();
+    private static readonly string _logFilePath = Path.Combine(AppContext.BaseDirectory, "diagnostic.log");
+
+    /// <summary>
+    /// Log an informational message with timestamp.
+    /// </summary>
+    public static void Log(string message)
+    {
+        string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        string formatted = $"[{timestamp}] LGSTray: {message}";
+        WriteToFile(formatted);
+        Debug.WriteLine(formatted);
+    }
+
+    /// <summary>
+    /// Log a warning message with timestamp.
+    /// </summary>
+    public static void LogWarning(string message)
+    {
+        string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        string formatted = $"[{timestamp}] LGSTray WARNING: {message}";
+        WriteToFile(formatted);
+        Debug.WriteLine(formatted);
+    }
+
+    /// <summary>
+    /// Log an error message with timestamp.
+    /// </summary>
+    public static void LogError(string message)
+    {
+        string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        string formatted = $"[{timestamp}] LGSTray ERROR: {message}";
+        WriteToFile(formatted);
+        Debug.WriteLine(formatted);
+    }
+
+    private static void WriteToFile(string message)
+    {
+        try
+        {
+            lock (_lock)
+            {
+                File.AppendAllText(_logFilePath, message + Environment.NewLine);
+            }
+        }
+        catch
+        {
+            // Silently fail if we can't write to log file
+        }
+    }
+}

--- a/LGSTrayUI/App.xaml.cs
+++ b/LGSTrayUI/App.xaml.cs
@@ -13,6 +13,7 @@ using Tommy.Extensions.Configuration;
 
 using static LGSTrayUI.AppExtensions;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace LGSTrayUI;
 
@@ -31,6 +32,12 @@ public partial class App : Application
         AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CrashHandler);
 
         EnableEfficiencyMode();
+        if (e.Args.Length > 0 && e.Args.Contains("--log"))
+        {
+            DiagnosticLogger.Enable=true;
+            DiagnosticLogger.ResetLog();
+        }
+        
 
         var builder = Host.CreateEmptyApplicationBuilder(null);
         await LoadAppSettings(builder.Configuration);

--- a/LGSTrayUI/App.xaml.cs
+++ b/LGSTrayUI/App.xaml.cs
@@ -60,7 +60,7 @@ public partial class App : Application
     {
         try
         {
-            config.AddTomlFile("appsettings.toml");
+            config.AddTomlFile(Path.Combine(AppContext.BaseDirectory, "appsettings.toml"));
         }
         catch (Exception ex)
         {
@@ -80,7 +80,7 @@ public partial class App : Application
                     );
                 }
 
-                config.AddTomlFile("appsettings.toml");
+                config.AddTomlFile(Path.Combine(AppContext.BaseDirectory, "appsettings.toml"));
             }
             else
             {

--- a/LGSTrayUI/LogiDeviceCollection.cs
+++ b/LGSTrayUI/LogiDeviceCollection.cs
@@ -1,4 +1,5 @@
 ﻿using LGSTrayCore;
+using LGSTrayPrimitives;
 using LGSTrayPrimitives.MessageStructs;
 using MessagePipe;
 using System;
@@ -83,7 +84,11 @@ namespace LGSTrayUI
 
             dev = _logiDeviceViewModelFactory.CreateViewModel((x) => x.UpdateState(initMessage));
 
-            Application.Current.Dispatcher.BeginInvoke(() => Devices.Add(dev));
+            Application.Current.Dispatcher.BeginInvoke(() =>
+            {
+                Devices.Add(dev);
+                DiagnosticLogger.Log($"Device added to collection - {initMessage.deviceId} ({initMessage.deviceName})");
+            });
         }
 
         public void OnUpdateMessage(UpdateMessage updateMessage)
@@ -91,7 +96,11 @@ namespace LGSTrayUI
             Application.Current.Dispatcher.BeginInvoke(() =>
             {
                 var device = Devices.FirstOrDefault(dev => dev.DeviceId == updateMessage.deviceId);
-                if (device == null) { return; }
+                if (device == null)
+                {
+                    DiagnosticLogger.LogWarning($"Update for unknown device - {updateMessage.deviceId}");
+                    return;
+                }
 
                 device.UpdateState(updateMessage);
             });


### PR DESCRIPTION
I have encountred problems detecting the MX Keys S and MX Anywhere 2 and increasing certain timings made it work.

The timing changes are in the last bfef1b81f6fe8b83d595a44a6c0cb37190639a95 and 70a024de1fd01a8d1a5388c22c81e16629174a26 commits, if you do not wish to include the added diagnostic logger.

I can't say I fully understand the messaging flow, will study further.