### PR TITLE
Fix device selection not persisting across restarts

### DIFF
--- a/LGSTrayHID/HidppDevice.cs
+++ b/LGSTrayHID/HidppDevice.cs
@@ -151,8 +151,10 @@ namespace LGSTrayHID
             }
             else
             {
-                // Device does not have a serial identifier the device name as a hash identifier
-                Identifier = $"{DeviceName.GetHashCode():X04}";
+                // Device does not have a serial identifier, use a stable hash of the device name
+                var hashBytes = System.Security.Cryptography.SHA256.HashData(
+                    System.Text.Encoding.UTF8.GetBytes(DeviceName));
+                Identifier = Convert.ToHexString(hashBytes, 0, 4);
             }
 
 #if DEBUG

--- a/LGSTrayUI/LogiDeviceCollection.cs
+++ b/LGSTrayUI/LogiDeviceCollection.cs
@@ -29,6 +29,8 @@ namespace LGSTrayUI
             _logiDeviceViewModelFactory = logiDeviceViewModelFactory;
             _subscriber = subscriber;
 
+            LoadPreviouslySelectedDevices();
+
             _subscriber.Subscribe(x =>
             {
                 if (x is InitMessage initMessage)
@@ -40,8 +42,6 @@ namespace LGSTrayUI
                     OnUpdateMessage(updateMessage);
                 }
             });
-
-            LoadPreviouslySelectedDevices();
         }
 
         private void LoadPreviouslySelectedDevices()
@@ -81,7 +81,12 @@ namespace LGSTrayUI
                 return;
             }
 
-            dev = _logiDeviceViewModelFactory.CreateViewModel((x) => x.UpdateState(initMessage));
+            bool wasSelected = _userSettings.SelectedDevices?.Contains(initMessage.deviceId) ?? false;
+            dev = _logiDeviceViewModelFactory.CreateViewModel((x) =>
+            {
+                x.UpdateState(initMessage);
+                x.IsChecked = wasSelected;
+            });
 
             Application.Current.Dispatcher.BeginInvoke(() => Devices.Add(dev));
         }


### PR DESCRIPTION
## Problem

After every PC restart, users must manually click \"Rediscover Devices\" and re-select their device. The battery icon either shows \"Not Initialised\" indefinitely or disappears entirely.

## Root cause

Three issues combine to cause this:

**1. `string.GetHashCode()` is non-deterministic in .NET Core (primary cause)**

In `HidppDevice.cs`, devices without HID++ feature `0x0003` fall back to:
```csharp
Identifier = $"{DeviceName.GetHashCode():X04}";
```
In .NET Core, `string.GetHashCode()` is randomized per-process by design. The same device name produces a different hash on every launch, so the saved device ID never matches the newly computed one. The placeholder created by `LoadPreviouslySelectedDevices` is never matched by `OnInitMessage`, which instead adds a second unchecked entry with the new hash — forcing the user to re-select every time.

**2. Startup race condition**

`LogiDeviceCollection` subscribed to device messages *before* calling `LoadPreviouslySelectedDevices()`. An `InitMessage` arriving in that narrow window would see an empty `Devices` list and create an unchecked entry, after which `LoadPreviouslySelectedDevices` would add a duplicate checked placeholder — causing a `SingleOrDefault` exception on subsequent messages.

**3. New devices not respecting saved selections**

When `OnInitMessage` creates a brand-new device entry (not found in `Devices`), it always set `IsChecked = false`, even if the device ID was in `SelectedDevices`.

## Fix

- **`LGSTrayHID/HidppDevice.cs`**: Replace `GetHashCode()` with `SHA256`, which is deterministic across processes and restarts.
- **`LGSTrayUI/LogiDeviceCollection.cs`**: Move `LoadPreviouslySelectedDevices()` before the subscriber setup to eliminate the race condition.
- **`LGSTrayUI/LogiDeviceCollection.cs`**: In `OnInitMessage`, pre-check newly discovered devices that are already in `SelectedDevices`.