### PR TITLE
Add per-device numeric icon appearance settings

### DIFF
--- a/LGSTrayUI/BatteryIconDrawing.cs
+++ b/LGSTrayUI/BatteryIconDrawing.cs
@@ -1,4 +1,4 @@
-using LGSTrayCore;
+﻿using LGSTrayCore;
 using LGSTrayUI.Properties;
 using System;
 using System.Drawing;
@@ -149,4 +149,3 @@ namespace LGSTrayUI
         }
     }
 }
-

--- a/LGSTrayUI/BatteryIconDrawing.cs
+++ b/LGSTrayUI/BatteryIconDrawing.cs
@@ -1,4 +1,4 @@
-﻿using LGSTrayCore;
+using LGSTrayCore;
 using LGSTrayUI.Properties;
 using System;
 using System.Drawing;
@@ -119,32 +119,34 @@ namespace LGSTrayUI
 
         public static void DrawNumeric(TaskbarIcon taskbarIcon, LogiDevice device)
         {
-            using Bitmap b = new(ImageSize, ImageSize);
-            using Graphics g = Graphics.FromImage(b);
-
-            string displayString = (device.BatteryPercentage < 0) ? "?" : $"{device.BatteryPercentage:f0}";
-            g.DrawString(
-                displayString,
-                new Font("Segoe UI", (int)(0.8 * ImageSize), GraphicsUnit.Pixel),
-                new SolidBrush(GetDeviceColor(device)),
-                ImageSize / 2, ImageSize / 2,
-                new(StringFormatFlags.FitBlackBox, 0)
-                {
-                    LineAlignment = StringAlignment.Center,
-                    Alignment = StringAlignment.Center,
-                }
-            );
-            g.CompositingMode = CompositingMode.SourceOver;
-            g.CompositingQuality = CompositingQuality.HighQuality;
-            g.InterpolationMode = InterpolationMode.HighQualityBicubic;
-            g.SmoothingMode = SmoothingMode.HighQuality;
-            g.PixelOffsetMode = PixelOffsetMode.HighQuality;
-
+            var colors = DeviceNumericColorStore.Resolve(Settings.Default.DeviceNumericColors,
+                device.DeviceId, Settings.Default.NumericTextColor, Settings.Default.NumericBackgroundColor, Settings.Default.NumericBold);
+            using Bitmap b = CreateNumericBitmap(device.BatteryPercentage,
+                NumericIconColors.Parse(colors.Text, GetDeviceColor(device)),
+                NumericIconColors.Parse(colors.Background, Color.Transparent), colors.Bold ?? false);
             IntPtr iconHandle = b.GetHicon();
             Icon tempManagedRes = Icon.FromHandle(iconHandle);
             taskbarIcon.Icon = (Icon)tempManagedRes.Clone();
             tempManagedRes.Dispose();
             DestroyIcon(iconHandle);
         }
+        public static Bitmap CreateNumericBitmap(double percentage, Color textColor, Color backgroundColor, bool bold = false)
+        {
+            Bitmap bitmap = new(ImageSize, ImageSize);
+            using Graphics graphics = Graphics.FromImage(bitmap);
+            graphics.Clear(backgroundColor);
+            graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAliasGridFit;
+            using Font font = new("Segoe UI", (int)(0.8 * ImageSize), bold ? FontStyle.Bold : FontStyle.Regular, GraphicsUnit.Pixel);
+            using SolidBrush brush = new(textColor);
+            using StringFormat format = new(StringFormatFlags.FitBlackBox, 0)
+            {
+                LineAlignment = StringAlignment.Center,
+                Alignment = StringAlignment.Center,
+            };
+            string text = percentage < 0 ? "?" : $"{percentage:f0}";
+            graphics.DrawString(text, font, brush, ImageSize / 2, ImageSize / 2, format);
+            return bitmap;
+        }
     }
 }
+

--- a/LGSTrayUI/DeviceNumericColorStore.cs
+++ b/LGSTrayUI/DeviceNumericColorStore.cs
@@ -31,4 +31,3 @@ public static class DeviceNumericColorStore
         return JsonSerializer.Serialize(entries);
     }
 }
-

--- a/LGSTrayUI/DeviceNumericColorStore.cs
+++ b/LGSTrayUI/DeviceNumericColorStore.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace LGSTrayUI;
+
+public sealed record DeviceNumericColors(string? Text = null, string? Background = null, bool? Bold = null);
+
+public static class DeviceNumericColorStore
+{
+    public static Dictionary<string, DeviceNumericColors> Read(string json)
+    {
+        try { return JsonSerializer.Deserialize<Dictionary<string, DeviceNumericColors>>(json) ?? new(); }
+        catch (JsonException) { return new(); }
+    }
+
+    public static DeviceNumericColors Get(string json, string deviceId) =>
+        Read(json).GetValueOrDefault(deviceId) ?? new();
+
+    public static DeviceNumericColors Resolve(string json, string deviceId, string text, string background, bool bold = false)
+    {
+        var device = Get(json, deviceId);
+        return new(device.Text ?? text, device.Background ?? background, device.Bold ?? bold);
+    }
+
+    public static string Set(string json, string deviceId, DeviceNumericColors colors)
+    {
+        var entries = Read(json);
+        if (colors.Text is null && colors.Background is null && colors.Bold is null) entries.Remove(deviceId);
+        else entries[deviceId] = colors;
+        return JsonSerializer.Serialize(entries);
+    }
+}
+

--- a/LGSTrayUI/LGSTrayUI.csproj
+++ b/LGSTrayUI/LGSTrayUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
@@ -81,4 +81,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/LGSTrayUI/LGSTrayUI.csproj
+++ b/LGSTrayUI/LGSTrayUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
@@ -10,6 +10,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <PublishSingleFile>true</PublishSingleFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <VersionPrefix>3.0.3</VersionPrefix>
@@ -80,3 +81,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/LGSTrayUI/LogiDeviceIcon.xaml.cs
+++ b/LGSTrayUI/LogiDeviceIcon.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Hardcodet.Wpf.TaskbarNotification;
+using Hardcodet.Wpf.TaskbarNotification;
 using LGSTrayCore;
 using LGSTrayPrimitives;
 using Microsoft.Extensions.Options;
@@ -113,6 +113,10 @@ namespace LGSTrayUI
                 _drawBatteryIcon = userSettings.NumericDisplay ? BatteryIconDrawing.DrawNumeric : BatteryIconDrawing.DrawIcon;
                 DrawBatteryIcon();
             }
+            else if (e.PropertyName is nameof(UserSettingsWrapper.NumericTextColor) or nameof(UserSettingsWrapper.NumericBackgroundColor) or "DeviceNumericColors" or nameof(UserSettingsWrapper.NumericBold))
+            {
+                DrawBatteryIcon();
+            }
         }
 
         private void LogiDevicePropertyChanged(object? s, PropertyChangedEventArgs e)
@@ -129,7 +133,12 @@ namespace LGSTrayUI
 
         private void DrawBatteryIcon()
         {
-            _ = Dispatcher.BeginInvoke(() => _drawBatteryIcon(taskbarIcon, (LogiDevice)DataContext));
+            if (disposedValue) return;
+            _ = Dispatcher.BeginInvoke(() =>
+            {
+                if (!disposedValue) _drawBatteryIcon(taskbarIcon, (LogiDevice)DataContext);
+            });
         }
     }
 }
+

--- a/LGSTrayUI/LogiDeviceIcon.xaml.cs
+++ b/LGSTrayUI/LogiDeviceIcon.xaml.cs
@@ -1,4 +1,4 @@
-using Hardcodet.Wpf.TaskbarNotification;
+﻿using Hardcodet.Wpf.TaskbarNotification;
 using LGSTrayCore;
 using LGSTrayPrimitives;
 using Microsoft.Extensions.Options;
@@ -141,4 +141,3 @@ namespace LGSTrayUI
         }
     }
 }
-

--- a/LGSTrayUI/NotifyIconResources.xaml
+++ b/LGSTrayUI/NotifyIconResources.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:LGSTrayUI"
                     xmlns:tb="http://www.hardcodet.net/taskbar">
@@ -41,4 +41,3 @@
                     ContextMenu="{StaticResource SysTrayMenu}">
     </tb:TaskbarIcon>
 </ResourceDictionary>
-

--- a/LGSTrayUI/NotifyIconResources.xaml
+++ b/LGSTrayUI/NotifyIconResources.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:LGSTrayUI"
                     xmlns:tb="http://www.hardcodet.net/taskbar">
@@ -27,6 +27,7 @@
         </MenuItem>
         <MenuItem Header="Rediscover Devices" Command="{Binding RediscoverDevicesCommand}" IsEnabled="{Binding RediscoverDevicesEnabled}"/>
         <MenuItem Header="Display Numeric Icon" IsCheckable="True" IsChecked="{Binding NumericDisplay}" StaysOpenOnClick="True" />
+        <MenuItem Header="Numeric Icon Appearance..." Command="{Binding OpenNumericColorsCommand}" />
         <MenuItem Header="Autostart with Windows" IsCheckable="True" IsChecked="{Binding AutoStart}" StaysOpenOnClick="True" />
         <Separator />
         <MenuItem Header="{Binding AssemblyVersion}" IsEnabled="False" />
@@ -40,3 +41,4 @@
                     ContextMenu="{StaticResource SysTrayMenu}">
     </tb:TaskbarIcon>
 </ResourceDictionary>
+

--- a/LGSTrayUI/NotifyIconViewModel.Colors.cs
+++ b/LGSTrayUI/NotifyIconViewModel.Colors.cs
@@ -1,0 +1,31 @@
+using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace LGSTrayUI;
+
+public partial class NotifyIconViewModel
+{
+    private NumericColorsWindow? _colorsWindow;
+
+    [RelayCommand]
+    private void OpenNumericColors()
+    {
+        // Let the tray popup finish releasing mouse capture before showing a real window.
+        ((ContextMenu)Application.Current.FindResource("SysTrayMenu")).IsOpen = false;
+        Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(() =>
+        {
+            if (_colorsWindow is null)
+            {
+                _colorsWindow = new NumericColorsWindow(_userSettings, LogiDevices);
+                _colorsWindow.Closed += (_, _) => _colorsWindow = null;
+                _colorsWindow.Show();
+            }
+            if (_colorsWindow.WindowState == WindowState.Minimized) _colorsWindow.WindowState = WindowState.Normal;
+            _colorsWindow.Activate();
+        }));
+    }
+}
+

--- a/LGSTrayUI/NotifyIconViewModel.Colors.cs
+++ b/LGSTrayUI/NotifyIconViewModel.Colors.cs
@@ -28,4 +28,3 @@ public partial class NotifyIconViewModel
         }));
     }
 }
-

--- a/LGSTrayUI/NumericColorsWindow.cs
+++ b/LGSTrayUI/NumericColorsWindow.cs
@@ -207,4 +207,3 @@ internal sealed class NumericColorEditor : StackPanel
             _hex.Text = NumericIconColors.Format(dialog.Color);
     }
 }
-

--- a/LGSTrayUI/NumericColorsWindow.cs
+++ b/LGSTrayUI/NumericColorsWindow.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Automation;
+using DrawingColor = System.Drawing.Color;
+
+namespace LGSTrayUI;
+
+public sealed class NumericColorsWindow : Window
+{
+    private readonly UserSettingsWrapper _settings;
+    private readonly ComboBox _devices = new() { MinWidth = 420, DisplayMemberPath = "Label" };
+    private readonly ComboBox _weight = new() { Margin = new Thickness(0, 6, 0, 14) };
+    private readonly NumericColorEditor _text = new("Text color", "Automatic (Windows theme)");
+    private readonly NumericColorEditor _background = new("Background color", "Transparent");
+    private readonly TextBlock _status = new() { Margin = new Thickness(0, 8, 0, 0) };
+    private readonly ObservableCollection<LogiDeviceViewModel> _source;
+    private string? _deviceId;
+    private bool _loading;
+
+    private sealed record DeviceChoice(string? Id, string Label);
+
+    public NumericColorsWindow(UserSettingsWrapper settings, ObservableCollection<LogiDeviceViewModel> devices)
+    {
+        _settings = settings;
+        _source = devices;
+        Title = "LGSTray - Numeric Icon Appearance";
+        Width = 590;
+        SizeToContent = SizeToContent.Height;
+        ResizeMode = ResizeMode.CanMinimize;
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        ShowInTaskbar = true;
+        Background = Brushes.White;
+        Foreground = Brushes.Black;
+        var panel = new StackPanel { Margin = new Thickness(22) };
+        panel.Children.Add(new TextBlock { Text = "Numeric icon appearance", FontSize = 23, FontWeight = FontWeights.SemiBold });
+        panel.Children.Add(new TextBlock { Text = "Choose a device, adjust its appearance, then click Apply.", Margin = new Thickness(0, 8, 0, 14) });
+        AutomationProperties.SetName(_devices, "Device");
+        panel.Children.Add(_devices);
+        var columns = new Grid { Margin = new Thickness(0, 18, 0, 12) };
+        columns.ColumnDefinitions.Add(new ColumnDefinition());
+        columns.ColumnDefinitions.Add(new ColumnDefinition());
+        _text.Margin = new Thickness(0, 0, 12, 0);
+        columns.Children.Add(_text);
+        Grid.SetColumn(_background, 1);
+        columns.Children.Add(_background);
+        panel.Children.Add(columns);
+        panel.Children.Add(new TextBlock { Text = "Font weight", FontWeight = FontWeights.SemiBold });
+        AutomationProperties.SetName(_weight, "Font weight");
+        panel.Children.Add(_weight);
+        var buttons = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
+        var apply = new Button { Content = "Apply", MinWidth = 95, Padding = new Thickness(12, 6, 12, 6), IsDefault = true };
+        apply.Click += (_, _) => SaveColors();
+        var close = new Button { Content = "Close", MinWidth = 95, Padding = new Thickness(12, 6, 12, 6), Margin = new Thickness(8, 0, 0, 0) };
+        close.Click += (_, _) => Close();
+        buttons.Children.Add(apply);
+        buttons.Children.Add(close);
+        panel.Children.Add(buttons);
+        panel.Children.Add(_status);
+        Content = panel;
+        RefreshDevices();
+        _devices.SelectionChanged += (_, _) => LoadColors();
+        _source.CollectionChanged += OnDevicesChanged;
+        Closed += (_, _) => _source.CollectionChanged -= OnDevicesChanged;
+        LoadColors();
+    }
+
+    private void OnDevicesChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) => RefreshDevices();
+
+    private void RefreshDevices()
+    {
+        var selected = _deviceId;
+        _loading = true;
+        _devices.Items.Clear();
+        _devices.Items.Add(new DeviceChoice(null, "Defaults (all devices)"));
+        foreach (var device in _source)
+            _devices.Items.Add(new DeviceChoice(device.DeviceId, $"{device.DeviceName} ({device.DeviceId})"));
+        _devices.SelectedIndex = 0;
+        foreach (DeviceChoice choice in _devices.Items)
+            if (choice.Id == selected) { _devices.SelectedItem = choice; break; }
+        _loading = false;
+    }
+
+    private void LoadColors()
+    {
+        if (_loading || _devices.SelectedItem is not DeviceChoice choice) return;
+        _deviceId = choice.Id;
+        var colors = _deviceId is null
+            ? new DeviceNumericColors(_settings.NumericTextColor, _settings.NumericBackgroundColor, _settings.NumericBold)
+            : _settings.GetDeviceNumericColors(_deviceId);
+        _text.Load(colors.Text, _deviceId is not null);
+        _background.Load(colors.Background, _deviceId is not null);
+        _weight.Items.Clear();
+        if (_deviceId is not null) _weight.Items.Add("Use default");
+        _weight.Items.Add("Normal");
+        _weight.Items.Add("Bold");
+        _weight.SelectedIndex = colors.Bold is null && _deviceId is not null ? 0 : (colors.Bold == true ? 1 : 0) + (_deviceId is null ? 0 : 1);
+        _status.Text = "Changes are saved only when you click Apply.";
+    }
+
+    private void SaveColors()
+    {
+        if (!_text.TryGetValue(out var text) || !_background.TryGetValue(out var background))
+        {
+            _status.Text = "Enter a valid hex color, for example #00AAFF.";
+            return;
+        }
+        try
+        {
+            if (_deviceId is null)
+            {
+                _settings.NumericTextColor = text ?? "";
+                _settings.NumericBackgroundColor = background ?? "";
+                _settings.NumericBold = _weight.SelectedIndex == 1;
+            }
+            else _settings.SetDeviceNumericColors(_deviceId, new(text, background, _weight.SelectedIndex == 0 ? null : _weight.SelectedIndex == 2));
+            _status.Text = "Saved. Enable Display Numeric Icon in the tray menu to see the colors.";
+        }
+        catch (System.Configuration.ConfigurationErrorsException)
+        {
+            _status.Text = "Could not save settings. Check access to your user settings folder.";
+        }
+    }
+}
+
+internal sealed class NumericColorEditor : StackPanel
+{
+    private readonly ComboBox _mode = new() { Margin = new Thickness(0, 8, 0, 8) };
+    private readonly TextBox _hex = new() { Margin = new Thickness(0, 6, 0, 8), MaxLength = 7 };
+
+    private readonly Border _swatch = new() { Height = 36, BorderBrush = Brushes.Gray, BorderThickness = new Thickness(1) };
+    private readonly StackPanel _custom = new();
+    private readonly string _automatic;
+
+    private bool _inherit;
+
+    public NumericColorEditor(string title, string automatic)
+    {
+        _automatic = automatic;
+        Children.Add(new TextBlock { Text = title, FontSize = 16, FontWeight = FontWeights.SemiBold });
+        AutomationProperties.SetName(_mode, title + " mode");
+        Children.Add(_mode);
+        _custom.Children.Add(_swatch);
+        AutomationProperties.SetName(_hex, title + " hex");
+        _custom.Children.Add(_hex);
+        var picker = new Button { Content = "Choose color...", Padding = new Thickness(10, 6, 10, 6) };
+        AutomationProperties.SetName(picker, title + " picker");
+        picker.Click += (_, _) => ChooseColor();
+        _custom.Children.Add(picker);
+        Children.Add(_custom);
+        _hex.TextChanged += (_, _) => HexChanged();
+        _mode.SelectionChanged += (_, _) => _custom.IsEnabled = _mode.SelectedIndex == (_inherit ? 2 : 1);
+    }
+
+    public void Load(string? value, bool inherit)
+    {
+        _inherit = inherit;
+        _mode.Items.Clear();
+        if (inherit) _mode.Items.Add("Use default colors");
+        _mode.Items.Add(_automatic);
+        _mode.Items.Add("Custom color");
+        _hex.Text = string.IsNullOrEmpty(value) ? "#FFFFFF" : value;
+        HexChanged();
+        _mode.SelectedIndex = value is null && inherit ? 0 : string.IsNullOrEmpty(value) ? (inherit ? 1 : 0) : (inherit ? 2 : 1);
+    }
+
+    public bool TryGetValue(out string? value)
+    {
+        value = null;
+        if (_inherit && _mode.SelectedIndex == 0) return true;
+        value = "";
+        if (_mode.SelectedIndex == (_inherit ? 1 : 0)) return true;
+        var parsed = NumericIconColors.Parse(_hex.Text, DrawingColor.Empty);
+        if (parsed.IsEmpty) return false;
+        value = NumericIconColors.Format(parsed);
+        return true;
+    }
+
+    private void HexChanged()
+    {
+        var color = NumericIconColors.Parse(_hex.Text, DrawingColor.Empty);
+        _hex.BorderBrush = color.IsEmpty ? Brushes.Red : SystemColors.ControlDarkBrush;
+        if (!color.IsEmpty)
+            _swatch.Background = new SolidColorBrush(Color.FromRgb(color.R, color.G, color.B));
+    }
+
+    private sealed class DialogOwner(IntPtr handle) : System.Windows.Forms.IWin32Window
+    {
+        public IntPtr Handle { get; } = handle;
+    }
+
+    private void ChooseColor()
+    {
+        var window = Window.GetWindow(this);
+        if (window is null) return;
+        // Own the native picker with the persistent settings window, never the tray popup.
+        var owner = new DialogOwner(new System.Windows.Interop.WindowInteropHelper(window).EnsureHandle());
+        using var dialog = new System.Windows.Forms.ColorDialog
+        {
+            FullOpen = true,
+            AnyColor = true,
+            Color = NumericIconColors.Parse(_hex.Text, DrawingColor.White)
+        };
+        if (dialog.ShowDialog(owner) == System.Windows.Forms.DialogResult.OK)
+            _hex.Text = NumericIconColors.Format(dialog.Color);
+    }
+}
+

--- a/LGSTrayUI/NumericIconColors.cs
+++ b/LGSTrayUI/NumericIconColors.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Drawing;
+using System.Globalization;
+
+namespace LGSTrayUI;
+
+public static class NumericIconColors
+{
+    public static Color Parse(string? value, Color fallback)
+    {
+        if (value is { Length: 7 } && value[0] == '#' &&
+            int.TryParse(value.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var rgb))
+            return Color.FromArgb(255, (rgb >> 16) & 255, (rgb >> 8) & 255, rgb & 255);
+        return fallback;
+    }
+
+    public static string Format(Color color) => $"#{color.R:X2}{color.G:X2}{color.B:X2}";
+}
+

--- a/LGSTrayUI/NumericIconColors.cs
+++ b/LGSTrayUI/NumericIconColors.cs
@@ -16,4 +16,3 @@ public static class NumericIconColors
 
     public static string Format(Color color) => $"#{color.R:X2}{color.G:X2}{color.B:X2}";
 }
-

--- a/LGSTrayUI/Properties/Settings.Colors.cs
+++ b/LGSTrayUI/Properties/Settings.Colors.cs
@@ -33,4 +33,3 @@ internal sealed partial class Settings
         set => this[nameof(NumericBackgroundColor)] = value;
     }
 }
-

--- a/LGSTrayUI/Properties/Settings.Colors.cs
+++ b/LGSTrayUI/Properties/Settings.Colors.cs
@@ -1,0 +1,36 @@
+using System.Configuration;
+
+namespace LGSTrayUI.Properties;
+
+internal sealed partial class Settings
+{
+    [UserScopedSetting, DefaultSettingValue("{}")]
+    public string DeviceNumericColors
+    {
+        get => (string)this[nameof(DeviceNumericColors)];
+        set => this[nameof(DeviceNumericColors)] = value;
+    }
+
+    [UserScopedSetting, DefaultSettingValue("False")]
+    public bool NumericBold
+    {
+        get => (bool)this[nameof(NumericBold)];
+        set => this[nameof(NumericBold)] = value;
+    }
+
+    // Empty values retain the original automatic text / transparent background.
+    [UserScopedSetting, DefaultSettingValue("")]
+    public string NumericTextColor
+    {
+        get => (string)this[nameof(NumericTextColor)];
+        set => this[nameof(NumericTextColor)] = value;
+    }
+
+    [UserScopedSetting, DefaultSettingValue("")]
+    public string NumericBackgroundColor
+    {
+        get => (string)this[nameof(NumericBackgroundColor)];
+        set => this[nameof(NumericBackgroundColor)] = value;
+    }
+}
+

--- a/LGSTrayUI/UserSettingsWrapper.cs
+++ b/LGSTrayUI/UserSettingsWrapper.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.Specialized;
 
 namespace LGSTrayUI
@@ -86,4 +86,3 @@ namespace LGSTrayUI
         }
     }
 }
-

--- a/LGSTrayUI/UserSettingsWrapper.cs
+++ b/LGSTrayUI/UserSettingsWrapper.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.Specialized;
 
 namespace LGSTrayUI
@@ -7,6 +7,50 @@ namespace LGSTrayUI
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "")]
         public StringCollection SelectedDevices => Properties.Settings.Default.SelectedDevices;
+
+        public DeviceNumericColors GetDeviceNumericColors(string deviceId) =>
+            DeviceNumericColorStore.Get(Properties.Settings.Default.DeviceNumericColors, deviceId);
+
+        public void SetDeviceNumericColors(string deviceId, DeviceNumericColors colors)
+        {
+            Properties.Settings.Default.DeviceNumericColors = DeviceNumericColorStore.Set(
+                Properties.Settings.Default.DeviceNumericColors, deviceId, colors);
+            Properties.Settings.Default.Save();
+            OnPropertyChanged("DeviceNumericColors");
+        }
+
+        public bool NumericBold
+        {
+            get => Properties.Settings.Default.NumericBold;
+            set
+            {
+                Properties.Settings.Default.NumericBold = value;
+                Properties.Settings.Default.Save();
+                OnPropertyChanged();
+            }
+        }
+
+        public string NumericTextColor
+        {
+            get => Properties.Settings.Default.NumericTextColor;
+            set
+            {
+                Properties.Settings.Default.NumericTextColor = value;
+                Properties.Settings.Default.Save();
+                OnPropertyChanged();
+            }
+        }
+
+        public string NumericBackgroundColor
+        {
+            get => Properties.Settings.Default.NumericBackgroundColor;
+            set
+            {
+                Properties.Settings.Default.NumericBackgroundColor = value;
+                Properties.Settings.Default.Save();
+                OnPropertyChanged();
+            }
+        }
 
         public bool NumericDisplay
         {
@@ -42,3 +86,4 @@ namespace LGSTrayUI
         }
     }
 }
+

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,9 @@ Depending on the number of devices selected in the context menu, multiple device
 
 Display the current battery percentage as a number.
 
+Numeric icon text color, background color, and font weight can be customized
+globally or per device from `Numeric Icon Appearance...` in the tray menu.
+
 *In numerical display mode, charging status will not be displayed*
 
 ### Reactive Icons
@@ -157,3 +160,4 @@ This project began as a task with me messing around with my mouse for battery tr
     - Mouse, By projecthayat, ID, In the Technology & computer hardware Collection
     - Keyboard, By HideMaru, ID, In the Electronic BL.2 Collection
     - Headphones, By Peter Lakenbrink, DE, In the School and Online Learning Glyph Collection
+

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# LGS Tray Battery
+﻿# LGS Tray Battery
 
 A rewrite/combination of my two programs [LGSTrayBattery](https://github.com/andyvorld/LGSTrayBattery) and [LGSTrayBattery_GHUB](https://github.com/andyvorld/LGSTrayBattery_GHUB), which should allow for interaction via both the native HID and Logitech GaminG Hub websockets.
 
@@ -160,4 +160,3 @@ This project began as a task with me messing around with my mouse for battery tr
     - Mouse, By projecthayat, ID, In the Technology & computer hardware Collection
     - Keyboard, By HideMaru, ID, In the Electronic BL.2 Collection
     - Headphones, By Peter Lakenbrink, DE, In the School and Online Learning Glyph Collection
-


### PR DESCRIPTION
Numeric tray icons currently follow the Windows theme and cannot be customized. This adds a persistent `Numeric Icon Appearance...` window where users can select global defaults or a device and configure text color, background color, and normal/bold font weight. Color selection uses an owned Windows color picker so it remains open after the tray context menu closes, and changes redraw active numeric icons immediately.

Validation:
- `dotnet build LGSTrayBattery.sln -c Debug --nologo`
- Exercised global and per-device persistence, inheritance/reset behavior, invalid HEX handling, owned color-picker cancellation, and normal/bold rendering in local UI checks.